### PR TITLE
Issue 4185

### DIFF
--- a/controllers/argocd_metrics_controller_test.go
+++ b/controllers/argocd_metrics_controller_test.go
@@ -29,7 +29,6 @@ import (
 	is "gotest.tools/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -349,7 +348,7 @@ func TestReconciler_add_dashboard(t *testing.T) {
 
 	// Need to create one configmap to test update existing versus create
 	cm := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "gitops-overview",
 			Namespace: dashboardNamespace,
 		},

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -472,9 +472,12 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 			changed = true
 		}
 
-		if !reflect.DeepEqual(existingArgoCD.Spec.NodePlacement, defaultArgoCDInstance.Spec.NodePlacement) {
-			existingArgoCD.Spec.NodePlacement = defaultArgoCDInstance.Spec.NodePlacement
-			changed = true
+		// if user is patching nodePlacement through GitopsService CR, then existingArgoCD NodePlacement is updated.
+		if defaultArgoCDInstance.Spec.NodePlacement != nil {
+			if !reflect.DeepEqual(existingArgoCD.Spec.NodePlacement, defaultArgoCDInstance.Spec.NodePlacement) {
+				existingArgoCD.Spec.NodePlacement = defaultArgoCDInstance.Spec.NodePlacement
+				changed = true
+			}
 		}
 
 		if changed {

--- a/controllers/gitopsservice_controller.go
+++ b/controllers/gitopsservice_controller.go
@@ -423,7 +423,6 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 		}
 	} else {
 		changed := false
-
 		if existingArgoCD.Spec.ApplicationSet != nil {
 			if existingArgoCD.Spec.ApplicationSet.Resources == nil {
 				existingArgoCD.Spec.ApplicationSet.Resources = defaultArgoCDInstance.Spec.ApplicationSet.Resources
@@ -478,6 +477,10 @@ func (r *ReconcileGitopsService) reconcileDefaultArgoCDInstance(instance *pipeli
 				existingArgoCD.Spec.NodePlacement = defaultArgoCDInstance.Spec.NodePlacement
 				changed = true
 			}
+			// Handle the case where NodePlacement should be removed
+		} else if existingArgoCD.Spec.NodePlacement != nil {
+			existingArgoCD.Spec.NodePlacement = defaultArgoCDInstance.Spec.NodePlacement
+			changed = true
 		}
 
 		if changed {


### PR DESCRIPTION
### **User description**
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**Test acceptance criteria**:

* [ ] Unit Test
* [ ] E2E Test

**How to test changes / Special notes to the reviewer**:


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix bug where ArgoCD `nodePlacement` stanza was removed unintentionally
  - Update reconciliation logic to handle `nodePlacement` correctly
  - Ensure removal only when intended, not by default

- Add unit test to verify correct handling of `nodePlacement`
  - Test updates via GitopsService CR and expected propagation

- Minor refactoring: unify metav1 import usage in tests


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitopsservice_controller.go</strong><dd><code>Fix and clarify ArgoCD nodePlacement reconciliation logic</code></dd></summary>
<hr>

controllers/gitopsservice_controller.go

<li>Fix reconciliation logic for <code>nodePlacement</code> in ArgoCD spec<br> <li> Ensure <code>nodePlacement</code> is only removed when intended<br> <li> Add comments to clarify logic


</details>


  </td>
  <td><a href="https://github.com/anandrkskd/gitops-operator/pull/1/files#diff-83cb198211fecd2e48f050de2a80a348f8525ade03f84535fbe925fb8dc3608a">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitopsservice_controller_test.go</strong><dd><code>Add and refactor tests for ArgoCD nodePlacement handling</code>&nbsp; </dd></summary>
<hr>

controllers/gitopsservice_controller_test.go

<li>Add unit test for ArgoCD <code>nodePlacement</code> update via GitopsService CR<br> <li> Refactor to use consistent metav1 import (<code>v1.ObjectMeta</code>)<br> <li> Assert correct propagation of nodeSelector to ArgoCD


</details>


  </td>
  <td><a href="https://github.com/anandrkskd/gitops-operator/pull/1/files#diff-931ac1c748a9047743bda1805c619e6fd0ab9cca57c335f4540257956c860893">+59/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>argocd_metrics_controller_test.go</strong><dd><code>Refactor test to use consistent metav1 import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

controllers/argocd_metrics_controller_test.go

<li>Refactor to use consistent metav1 import (<code>v1.ObjectMeta</code>)<br> <li> Minor test code cleanup


</details>


  </td>
  <td><a href="https://github.com/anandrkskd/gitops-operator/pull/1/files#diff-21df7179a77167df3cf6d147100c056d6213c9f1b8417b6be0ef14efcfef8880">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>